### PR TITLE
[codex] Switch toolbox shell to fish

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ ENV LANG=en_US.UTF-8 \
 
 RUN dnf -y upgrade && \
     dnf -y install \
-      bash-completion bc bind-utils bzip2 curl dbus dbus-daemon dbus-tools diffutils fd-find findutils fuse-overlayfs fzf gcc gcc-c++ git git-lfs glib2 glib2-devel glibc-langpack-en gnupg2 golang hostname iproute iputils jq keyutils krb5-libs less libX11-devel libXcursor-devel libXi-devel libXinerama-devel libXrandr-devel libXxf86vm-devel libei-utils libxcrypt-compat.x86_64 libxkbcommon-devel lsof make man-db man-pages mesa-libGL-devel mtr ncurses ninja-build nmap-ncat npm openssl pam passwd pigz pinentry pipx pkgconf-pkg-config podman-compose podman-remote postgresql ripgrep rust cargo rustfmt rsync shadow-utils slirp4netns sqlite strace sudo tcpdump time traceroute tree unzip util-linux util-linux-script vte-profile wev weston weston-demo wget which whois wl-clipboard words wtype xdg-dbus-proxy xdg-utils xorg-x11-xauth xz ydotool zip zsh \
+      bash-completion bat bc bind-utils bzip2 curl dbus dbus-daemon dbus-tools diffutils eza fd-find ffmpeg-free findutils fish fuse-overlayfs fzf gcc gcc-c++ git git-delta git-lfs glib2 glib2-devel glibc-langpack-en gnupg2 golang hostname ImageMagick iproute iputils jq just keyutils krb5-libs less libX11-devel libXcursor-devel libXi-devel libXinerama-devel libXrandr-devel libXxf86vm-devel libei-utils libxcrypt-compat.x86_64 libxkbcommon-devel lsof make man-db man-pages mesa-libGL-devel mtr ncurses ninja-build nmap-ncat npm openssl pam passwd pigz pinentry pipx pkgconf-pkg-config podman-compose podman-remote postgresql ripgrep rust cargo rustfmt rsync shadow-utils ShellCheck shfmt slirp4netns sqlite strace sudo tcpdump time traceroute tree unzip util-linux util-linux-script vte-profile wev weston weston-demo wget which whois wl-clipboard words wtype xdg-dbus-proxy xdg-utils xorg-x11-xauth xz ydotool yq yt-dlp zip \
       cmake clang clang-tools-extra java-21-openjdk java-21-openjdk-devel python3 python3-devel python3-pip python3.12 python3.12-devel python3-dotenv python3-lxml python3-pyyaml && \
     dnf clean all
 
@@ -62,42 +62,26 @@ RUN curl -fsSL https://bun.sh/install | bash && \
     corepack enable && \
     curl -fsSL https://deno.land/install.sh | DENO_INSTALL=/usr/local sh
 
-RUN git clone --depth=1 https://github.com/ohmyzsh/ohmyzsh.git /opt/oh-my-zsh && \
-    git clone --depth=1 https://github.com/romkatv/powerlevel10k.git /opt/oh-my-zsh/custom/themes/powerlevel10k && \
-    git clone --depth=1 https://github.com/zsh-users/zsh-autosuggestions.git /opt/oh-my-zsh/custom/plugins/zsh-autosuggestions && \
-    git clone --depth=1 https://github.com/zsh-users/zsh-syntax-highlighting.git /opt/oh-my-zsh/custom/plugins/zsh-syntax-highlighting && \
-    chmod -R go-w /opt/oh-my-zsh
+RUN curl -fsSL https://starship.rs/install.sh | sh -s -- --yes --bin-dir /usr/bin && \
+    mkdir -p /usr/share/fish/vendor_conf.d /usr/share/fish/vendor_functions.d /usr/share/fish/vendor_completions.d && \
+    curl -fsSL https://raw.githubusercontent.com/jorgebucaran/fisher/main/functions/fisher.fish -o /usr/share/fish/vendor_functions.d/fisher.fish && \
+    curl -fsSL https://raw.githubusercontent.com/jorgebucaran/fisher/main/completions/fisher.fish -o /usr/share/fish/vendor_completions.d/fisher.fish && \
+    git clone --depth=1 https://github.com/chelokot/starship-show-on-command.fish.git /tmp/starship-show-on-command.fish && \
+    cp /tmp/starship-show-on-command.fish/conf.d/*.fish /usr/share/fish/vendor_conf.d/ && \
+    cp /tmp/starship-show-on-command.fish/functions/*.fish /usr/share/fish/vendor_functions.d/ && \
+    rm -rf /tmp/starship-show-on-command.fish
 
-RUN printf '%s\n' '\
-typeset -g POWERLEVEL9K_LEFT_PROMPT_ELEMENTS=(dir vcs)\n\
-typeset -g POWERLEVEL9K_RIGHT_PROMPT_ELEMENTS=(status command_execution_time time)\n\
-typeset -g POWERLEVEL9K_PROMPT_ON_NEWLINE=true\n\
-typeset -g POWERLEVEL9K_MULTILINE_FIRST_PROMPT_PREFIX=""\n\
-typeset -g POWERLEVEL9K_MULTILINE_LAST_PROMPT_PREFIX=">>> "\n\
-typeset -g POWERLEVEL9K_TIME_FORMAT=%D{%H:%M:%S}\n\
-typeset -g POWERLEVEL9K_MODE=compatible\n\
-typeset -g POWERLEVEL9K_SHORTEN_STRATEGY=truncate_to_unique\n\
-typeset -g POWERLEVEL9K_SHORTEN_DIR_LENGTH=3\n\
-typeset -g POWERLEVEL9K_VCS_MAX_INDEX_SIZE_DIRTY=-1\n\
-' > /etc/p10k.zsh
-
-RUN printf '%s\n' '\
-export ZSH=/opt/oh-my-zsh\n\
-export ZSH_DISABLE_COMPFIX=true\n\
-export DISABLE_AUTO_TITLE=true\n\
-ZSH_COMPDUMP=${XDG_CACHE_HOME:-/tmp}/zsh/.zcompdump-$HOST-$UID\n\
-mkdir -p ${ZSH_COMPDUMP:h} 2>/dev/null || true\n\
-autoload -Uz compinit; compinit -C -d "$ZSH_COMPDUMP"\n\
-plugins=(git fzf zsh-autosuggestions zsh-syntax-highlighting)\n\
-ZSH_THEME="powerlevel10k/powerlevel10k"\n\
-source $ZSH/oh-my-zsh.sh\n\
-[ -r /usr/share/fzf/shell/key-bindings.zsh ] && source /usr/share/fzf/shell/key-bindings.zsh\n\
-[ -r /etc/p10k.zsh ] && source /etc/p10k.zsh\n\
-' > /etc/zshrc
-
-COPY skel-zshrc /etc/skel/.zshrc
-RUN chsh -s /usr/bin/zsh root || true && \
-    printf 'if [ -n "$BASH_VERSION" -a -t 1 ]; then exec /usr/bin/zsh -l; fi\n' > /etc/profile.d/90-auto-zsh.sh
+RUN mkdir -p /etc/skel/.config/fish
+COPY fish/config.fish /etc/skel/.config/fish/config.fish
+COPY fish/fish_plugins /etc/skel/.config/fish/fish_plugins
+COPY starship.toml /etc/starship.toml
+COPY starship.toml /etc/skel/.config/starship.toml
+RUN mkdir -p /root/.config/fish && \
+    cp /etc/skel/.config/fish/config.fish /root/.config/fish/config.fish && \
+    cp /etc/skel/.config/fish/fish_plugins /root/.config/fish/fish_plugins && \
+    cp /etc/skel/.config/starship.toml /root/.config/starship.toml && \
+    chsh -s /usr/bin/fish root || true && \
+    printf 'if [ -n "$BASH_VERSION" -a -t 1 ] && [ -z "$FEDORA_TOOLBOX_NO_AUTO_FISH" ]; then exec /usr/bin/fish -l; fi\n' > /etc/profile.d/90-auto-fish.sh
 
 RUN for bin in xdg-open gio dbus-run-session systemctl distrobox; do \
       printf '#!/usr/bin/env sh\nif [ -n "${DISTROBOX_ENTER_PATH:-}" ] && command -v distrobox-host-exec >/dev/null 2>&1; then exec distrobox-host-exec %s "$@"; fi\nexec /usr/bin/%s "$@"\n' "$bin" "$bin" > "/usr/local/bin/$bin"; \

--- a/README.md
+++ b/README.md
@@ -19,3 +19,5 @@ distrobox-export --app app-name
 Inside Distrobox, `xdg-open`, `gio`, `dbus-run-session`, `podman`, `docker`, `distrobox`, and `systemctl` call the host through `distrobox-host-exec`. This keeps browser/link opening, host containers, and host systemd commands usable from the dev shell.
 
 Codex is installed with Bun in the image. Runtime state stays in the mounted home directory under `$HOME/.codex`.
+
+Fish is the default shell for repo-managed Distrobox containers. The image includes Starship, Fisher, and `chelokot/starship-show-on-command.fish`; default fish and Starship configs are copied into `/etc/skel`.

--- a/distrobox.ini
+++ b/distrobox.ini
@@ -5,3 +5,4 @@ replace=false
 start_now=true
 init=false
 nvidia=false
+init_hooks=usermod --shell /usr/bin/fish "$USER";

--- a/fish/config.fish
+++ b/fish/config.fish
@@ -1,0 +1,65 @@
+if status is-interactive
+    starship init fish | source
+
+    function __chelokot_container_context
+        test -r /run/.containerenv; or return
+
+        set -l name (sed -n 's/^name="\([^"]*\)"$/\1/p' /run/.containerenv)
+        test -n "$name"; or return
+
+        set_color --dim yellow
+        printf '  %s' "$name"
+        set_color normal
+    end
+
+    function fish_right_prompt
+    end
+
+    function fish_prompt
+        switch "$fish_key_bindings"
+            case fish_hybrid_key_bindings fish_vi_key_bindings fish_helix_key_bindings
+                set STARSHIP_KEYMAP "$fish_bind_mode"
+            case '*'
+                set STARSHIP_KEYMAP insert
+        end
+
+        set STARSHIP_CMD_PIPESTATUS $pipestatus
+        set STARSHIP_CMD_STATUS $status
+        set STARSHIP_DURATION "$CMD_DURATION$cmd_duration"
+
+        if contains -- --final-rendering $argv
+            if test "$STARSHIP_CMD_STATUS" -eq 0
+                printf "\e[1;32m❯\e[0m "
+            else
+                printf "\e[1;31m❯\e[0m "
+            end
+            return
+        end
+
+        __starship_set_job_count
+
+        set -l prompt_lines (/usr/bin/starship prompt --terminal-width="$COLUMNS" --status=$STARSHIP_CMD_STATUS --pipestatus="$STARSHIP_CMD_PIPESTATUS" --keymap=$STARSHIP_KEYMAP --cmd-duration=$STARSHIP_DURATION --jobs=$STARSHIP_JOBS | string split \n)
+        set -l right_context (__chelokot_container_context)
+
+        if test (count $prompt_lines) -eq 0
+            return
+        end
+
+        set -l first_line $prompt_lines[1]
+        set -l right_width (string length --visible -- "$right_context")
+        set -l right_column (math "$COLUMNS - $right_width - 1")
+
+        if test -n "$right_context"; and test "$right_column" -gt 1
+            printf '%s' "$first_line"
+            printf '\e[s\e[%dG  %s\e[u\n' "$right_column" "$right_context"
+        else
+            printf '%s\n' "$first_line"
+        end
+
+        if test (count $prompt_lines) -gt 1
+            printf '%s' "$prompt_lines[2]"
+        end
+    end
+
+    set -g fish_transient_prompt 1
+end

--- a/fish/fish_plugins
+++ b/fish/fish_plugins
@@ -1,0 +1,2 @@
+jorgebucaran/fisher
+chelokot/starship-show-on-command.fish

--- a/skel-zshrc
+++ b/skel-zshrc
@@ -1,4 +1,0 @@
-export ZSH=/opt/oh-my-zsh
-ZSH_THEME="powerlevel10k/powerlevel10k"
-plugins=(git zsh-autosuggestions zsh-syntax-highlighting)
-source $ZSH/oh-my-zsh.sh

--- a/starship.toml
+++ b/starship.toml
@@ -1,0 +1,65 @@
+format = "$username$hostname$localip$shlvl$singularity$kubernetes$nats$directory$vcsh$fossil_branch$fossil_metrics$git_branch$git_commit$git_state$git_metrics$git_status$hg_branch$hg_state$pijul_channel$docker_context$package$bun$c$cmake$cobol$cpp$daml$dart$deno$dotnet$elixir$elm$erlang$fennel$fortran$gleam$golang$gradle$haskell$haxe$helm$java$julia$kotlin$lua$mojo$nim$nodejs$ocaml$odin$opa$perl$php$pulumi$purescript$python$quarto$raku$rlang$red$ruby$rust$scala$solidity$swift$terraform$typst$vlang$vagrant$xmake$zig$buf$guix_shell$nix_shell$conda$pixi$meson$spack$memory_usage$gcloud$openstack$azure$direnv$env_var$mise$crystal$sudo$cmd_duration$status${custom.aws_on_command}${custom.kube_on_command}${custom.gcloud_on_command}${custom.python_on_command}$line_break$jobs$battery$time$netns$os$shell$character"
+right_format = ""
+add_newline = false
+
+[directory]
+home_symbol = "~"
+truncate_to_repo = false
+truncation_length = 0
+truncation_symbol = ""
+
+
+[aws]
+disabled = true
+
+[container]
+disabled = true
+
+
+[kubernetes]
+disabled = true
+
+[gcloud]
+disabled = true
+
+[python]
+disabled = true
+
+
+# >>> starship-show-on-command.fish >>>
+[custom.aws_on_command]
+when = "test \"$STARSHIP_SOC_AWS\" = 1"
+command = "printf '%s' \"$STARSHIP_SOC_AWS_CONTEXT\""
+shell = ["sh"]
+style = "bold yellow"
+format = "on [$output]($style) "
+
+[custom.kube_on_command]
+when = "test \"$STARSHIP_SOC_KUBE\" = 1"
+command = "printf '%s' \"$STARSHIP_SOC_KUBE_CONTEXT\""
+shell = ["sh"]
+style = "bold blue"
+format = "on [$output]($style) "
+
+[custom.gcloud_on_command]
+when = "test \"$STARSHIP_SOC_GCLOUD\" = 1"
+command = "printf '%s' \"$STARSHIP_SOC_GCLOUD_CONTEXT\""
+shell = ["sh"]
+style = "bold blue"
+format = "on [$output]($style) "
+
+[custom.python_on_command]
+when = "test \"$STARSHIP_SOC_PYTHON\" = 1"
+command = "printf '%s' \"$STARSHIP_SOC_PYTHON_CONTEXT\""
+shell = ["sh"]
+style = "bold green"
+format = "via [$output]($style) "
+
+[custom.memory_on_command]
+when = "test \"$STARSHIP_SOC_MEMORY\" = 1"
+command = "printf '%s' \"$STARSHIP_SOC_MEMORY_CONTEXT\""
+shell = ["sh"]
+style = "bold purple"
+format = "via [$output]($style) "
+
+# <<< starship-show-on-command.fish <<<

--- a/test/build/smoke.sh
+++ b/test/build/smoke.sh
@@ -11,9 +11,14 @@ required_bins=(
   curl
   dbus-run-session
   deno
+  delta
   distrobox
   docker
+  eza
   fd
+  ffmpeg
+  ffprobe
+  fish
   fzf
   gcc
   gh
@@ -26,7 +31,9 @@ required_bins=(
   helmfile
   ei-debug-events
   jq
+  just
   kubectl
+  magick
   make
   mypy
   node
@@ -40,7 +47,10 @@ required_bins=(
   python3.12
   rg
   ruff
+  shellcheck
+  shfmt
   sqlite3
+  starship
   systemctl
   terraform
   ts-node
@@ -53,8 +63,9 @@ required_bins=(
   wtype
   xdg-open
   yamllint
+  yq
+  yt-dlp
   ydotool
-  zsh
 )
 
 for bin in "${required_bins[@]}"; do
@@ -120,13 +131,20 @@ az version --output none
 bun --version
 codex --version
 deno --version
+delta --version
+eza --version
+ffmpeg -version >/dev/null
+ffprobe -version >/dev/null
+fish --version
 gh --version
 glab --version
 gcloud --version
 go version
 helm version --short
-helmfile version
+helmfile --version
+just --version
 kubectl version --client=true
+magick -version
 node --version
 npm --version
 openstack --version
@@ -134,10 +152,16 @@ poetry --version
 python3 --version
 python3.12 --version
 rustc --version
+shellcheck --version
+shfmt --version
+starship --version
 terraform version
 ts-node --version
 tsc --version
 uv --version
+yq --version
+yt-dlp --version
+fish -lc 'functions -q fisher; functions -q starship-soc; test -r /etc/starship.toml; test -r /etc/skel/.config/fish/config.fish; test -r /etc/skel/.config/fish/fish_plugins; test -r /etc/skel/.config/starship.toml'
 
 if [ -n "${DISTROBOX_ENTER_PATH:-}" ]; then
   command -v distrobox-export >/dev/null
@@ -147,5 +171,6 @@ test ! -d /root/.config/gcloud/legacy_credentials
 test ! -e /run/secrets/gcp_key.json
 test ! -d /opt/ComfyUI
 ! command -v ollama >/dev/null
+! command -v zsh >/dev/null
 
 echo "basic toolbox tools work"


### PR DESCRIPTION
## Summary
- replace zsh/Oh My Zsh/Powerlevel10k setup with fish, Starship, Fisher, and chelokot/starship-show-on-command.fish
- add fish and Starship defaults to the image skeleton and Distrobox config
- add small everyday tools including ffmpeg, yt-dlp, yq, just, bat, delta, eza, shellcheck, shfmt, and ImageMagick
- update smoke coverage to require fish tooling and assert zsh is absent

## Validation
- bash -n test/build/smoke.sh test/runtime/smoke.sh
- fish -n fish/config.fish
- env STARSHIP_CONFIG=starship.toml starship explain >/dev/null
- git diff --check

Note: no final local image build was run for this PR after scope was corrected.