### PR TITLE
[codex] Import ExposedCat fish snippets

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 FROM quay.io/fedora/fedora-toolbox:43
 
+ARG EXPOSEDCAT_DOTFILES_REF=0b9071e95f67f67dabb917d761a4fa2948c1148e
+
 ENV LANG=en_US.UTF-8 \
     LC_ALL=en_US.UTF-8 \
     BUN_INSTALL=/opt/bun \
@@ -71,7 +73,15 @@ RUN curl -fsSL https://starship.rs/install.sh | sh -s -- --yes --bin-dir /usr/bi
     cp /tmp/starship-show-on-command.fish/functions/*.fish /usr/share/fish/vendor_functions.d/ && \
     rm -rf /tmp/starship-show-on-command.fish
 
-RUN mkdir -p /etc/skel/.config/fish
+RUN mkdir -p /etc/fish/conf.d /etc/skel/.config/fish && \
+    curl -fsSL "https://raw.githubusercontent.com/ExposedCat/dotfiles/${EXPOSEDCAT_DOTFILES_REF}/fish/colors.fish" -o /etc/fish/conf.d/10-exposedcat-colors.fish && \
+    sed -i \
+      -e 's/^set -Ux fish_color_command .*/set -Ux fish_color_command 7ee787/' \
+      -e 's/^set -Ux fish_color_error .*/set -Ux fish_color_error ff6b81/' \
+      /etc/fish/conf.d/10-exposedcat-colors.fish && \
+    curl -fsSL "https://raw.githubusercontent.com/ExposedCat/dotfiles/${EXPOSEDCAT_DOTFILES_REF}/fish/config.fish" -o /tmp/exposedcat-config.fish && \
+    grep -E '^[[:space:]]*set[[:space:]]+-g[[:space:]]+fish_greeting([[:space:]]|$)' /tmp/exposedcat-config.fish > /etc/fish/conf.d/00-exposedcat-greeting.fish && \
+    rm -f /tmp/exposedcat-config.fish
 COPY fish/config.fish /etc/skel/.config/fish/config.fish
 COPY fish/fish_plugins /etc/skel/.config/fish/fish_plugins
 COPY starship.toml /etc/starship.toml

--- a/distrobox.ini
+++ b/distrobox.ini
@@ -5,4 +5,4 @@ replace=false
 start_now=true
 init=false
 nvidia=false
-init_hooks=usermod --shell /usr/bin/fish "$USER";
+pre_init_hooks=export SHELL=/usr/bin/fish;

--- a/test/build/smoke.sh
+++ b/test/build/smoke.sh
@@ -161,7 +161,7 @@ tsc --version
 uv --version
 yq --version
 yt-dlp --version
-fish -lc 'functions -q fisher; functions -q starship-soc; test -r /etc/starship.toml; test -r /etc/skel/.config/fish/config.fish; test -r /etc/skel/.config/fish/fish_plugins; test -r /etc/skel/.config/starship.toml'
+fish -lc "functions -q fisher; functions -q starship-soc; test -r /etc/starship.toml; test -r /etc/skel/.config/fish/config.fish; test -r /etc/skel/.config/fish/fish_plugins; test -r /etc/fish/conf.d/00-exposedcat-greeting.fish; test -r /etc/fish/conf.d/10-exposedcat-colors.fish; test -r /etc/skel/.config/starship.toml; test \"\$fish_greeting\" = \"\"; test \"\$fish_color_command\" = 7ee787; test \"\$fish_color_error\" = ff6b81"
 
 if [ -n "${DISTROBOX_ENTER_PATH:-}" ]; then
   command -v distrobox-export >/dev/null
@@ -170,7 +170,11 @@ fi
 test ! -d /root/.config/gcloud/legacy_credentials
 test ! -e /run/secrets/gcp_key.json
 test ! -d /opt/ComfyUI
-! command -v ollama >/dev/null
-! command -v zsh >/dev/null
+if command -v ollama >/dev/null; then
+  exit 1
+fi
+if command -v zsh >/dev/null; then
+  exit 1
+fi
 
 echo "basic toolbox tools work"


### PR DESCRIPTION
## Summary
- Pull ExposedCat fish color and greeting snippets at build time from a pinned dotfiles ref.
- Override the command and error colors with the brighter live-tested values.
- Keep the Distrobox shell setup change in the same PR and extend the smoke check coverage.

## Validation
- `bash -n test/build/smoke.sh test/runtime/smoke.sh`
- `shellcheck test/build/smoke.sh test/runtime/smoke.sh`
- Downloaded the pinned ExposedCat `colors.fish`, applied the same color overrides, and checked it with `fish -n`.