### PR TITLE
[codex] Trim Distrobox fish startup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -73,7 +73,7 @@ RUN curl -fsSL https://starship.rs/install.sh | sh -s -- --yes --bin-dir /usr/bi
     cp /tmp/starship-show-on-command.fish/functions/*.fish /usr/share/fish/vendor_functions.d/ && \
     rm -rf /tmp/starship-show-on-command.fish
 
-RUN mkdir -p /etc/fish/conf.d /etc/skel/.config/fish && \
+RUN mkdir -p /etc/fish/conf.d /etc/skel/.config/fish/conf.d && \
     curl -fsSL "https://raw.githubusercontent.com/ExposedCat/dotfiles/${EXPOSEDCAT_DOTFILES_REF}/fish/colors.fish" -o /etc/fish/conf.d/10-exposedcat-colors.fish && \
     sed -i \
       -e 's/^set -Ux fish_color_command .*/set -Ux fish_color_command 7ee787/' \
@@ -83,11 +83,13 @@ RUN mkdir -p /etc/fish/conf.d /etc/skel/.config/fish && \
     grep -E '^[[:space:]]*set[[:space:]]+-g[[:space:]]+fish_greeting([[:space:]]|$)' /tmp/exposedcat-config.fish > /etc/fish/conf.d/00-exposedcat-greeting.fish && \
     rm -f /tmp/exposedcat-config.fish
 COPY fish/config.fish /etc/skel/.config/fish/config.fish
+COPY fish/conf.d/distrobox_config.fish /etc/skel/.config/fish/conf.d/distrobox_config.fish
 COPY fish/fish_plugins /etc/skel/.config/fish/fish_plugins
 COPY starship.toml /etc/starship.toml
 COPY starship.toml /etc/skel/.config/starship.toml
-RUN mkdir -p /root/.config/fish && \
+RUN mkdir -p /root/.config/fish/conf.d && \
     cp /etc/skel/.config/fish/config.fish /root/.config/fish/config.fish && \
+    cp /etc/skel/.config/fish/conf.d/distrobox_config.fish /root/.config/fish/conf.d/distrobox_config.fish && \
     cp /etc/skel/.config/fish/fish_plugins /root/.config/fish/fish_plugins && \
     cp /etc/skel/.config/starship.toml /root/.config/starship.toml && \
     chsh -s /usr/bin/fish root || true && \

--- a/fish/conf.d/distrobox_config.fish
+++ b/fish/conf.d/distrobox_config.fish
@@ -1,0 +1,15 @@
+if status --is-interactive
+    test -z "$USER"; and set -gx USER (id -un 2>/dev/null)
+    test -z "$UID"; and set -gx UID (id -ur 2>/dev/null)
+    test -z "$EUID"; and set -gx EUID (id -u 2>/dev/null)
+
+    test -z "$XDG_RUNTIME_DIR"; and set -gx XDG_RUNTIME_DIR /run/user/(id -ru)
+    test -z "$DBUS_SESSION_BUS_ADDRESS"; and set -gx DBUS_SESSION_BUS_ADDRESS unix:path=$XDG_RUNTIME_DIR/bus
+
+    if test -e /var/tmp/.$USER.passwd.initialize
+        echo "First time user password setup"
+        trap "echo; exit" INT
+        passwd; and rm -f /var/tmp/.$USER.passwd.initialize
+        trap - INT
+    end
+end

--- a/test/build/smoke.sh
+++ b/test/build/smoke.sh
@@ -161,7 +161,7 @@ tsc --version
 uv --version
 yq --version
 yt-dlp --version
-fish -lc "functions -q fisher; functions -q starship-soc; test -r /etc/starship.toml; test -r /etc/skel/.config/fish/config.fish; test -r /etc/skel/.config/fish/fish_plugins; test -r /etc/fish/conf.d/00-exposedcat-greeting.fish; test -r /etc/fish/conf.d/10-exposedcat-colors.fish; test -r /etc/skel/.config/starship.toml; test \"\$fish_greeting\" = \"\"; test \"\$fish_color_command\" = 7ee787; test \"\$fish_color_error\" = ff6b81"
+fish -lc "functions -q fisher; functions -q starship-soc; test -r /etc/starship.toml; test -r /etc/skel/.config/fish/config.fish; test -r /etc/skel/.config/fish/conf.d/distrobox_config.fish; test -r /etc/skel/.config/fish/fish_plugins; test -r /etc/fish/conf.d/00-exposedcat-greeting.fish; test -r /etc/fish/conf.d/10-exposedcat-colors.fish; test -r /etc/skel/.config/starship.toml; test \"\$fish_greeting\" = \"\"; test \"\$fish_color_command\" = 7ee787; test \"\$fish_color_error\" = ff6b81"
 
 if [ -n "${DISTROBOX_ENTER_PATH:-}" ]; then
   command -v distrobox-export >/dev/null


### PR DESCRIPTION
## Summary
- add a user-level fish override for Distrobox startup config in the toolbox image
- avoid host-spawn GUI env lookups during fish startup
- verify the override is present in the build smoke check

## Validation
- git diff --check
- fish -n fish/config.fish fish/conf.d/distrobox_config.fish
- bash -n test/build/smoke.sh test/runtime/smoke.sh
- shellcheck test/build/smoke.sh test/runtime/smoke.sh