### PR TITLE
[codex] Add fast Ptyxis toolbox shell

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,3 +21,5 @@ Inside Distrobox, `xdg-open`, `gio`, `dbus-run-session`, `podman`, `docker`, `di
 Codex is installed with Bun in the image. Runtime state stays in the mounted home directory under `$HOME/.codex`.
 
 Fish is the default shell for repo-managed Distrobox containers. The image includes Starship, Fisher, and `chelokot/starship-show-on-command.fish`; default fish and Starship configs are copied into `/etc/skel`.
+
+For Ptyxis profiles that should open this toolbox quickly, use `host/fedora-toolbox-fast-shell` as a host-side custom command. It skips Distrobox's per-tab environment builder for already running containers and goes directly through `podman exec`.

--- a/host/fedora-toolbox-fast-shell
+++ b/host/fedora-toolbox-fast-shell
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+container="${FEDORA_TOOLBOX_CONTAINER:-fedora-toolbox}"
+user="${FEDORA_TOOLBOX_USER:-${USER:-chelokot}}"
+workdir="${PWD:-$HOME}"
+
+if [[ ! -d "$workdir" ]]; then
+  workdir="$HOME"
+fi
+
+env_args=()
+for name in \
+  COLORTERM \
+  DBUS_SESSION_BUS_ADDRESS \
+  DESKTOP_SESSION \
+  DISPLAY \
+  LANG \
+  PTYXIS_PROFILE \
+  PTYXIS_VERSION \
+  SSH_AUTH_SOCK \
+  TERM \
+  VTE_VERSION \
+  WAYLAND_DISPLAY \
+  XAUTHORITY \
+  XDG_CURRENT_DESKTOP \
+  XDG_DATA_DIRS \
+  XDG_MENU_PREFIX \
+  XDG_RUNTIME_DIR \
+  XDG_SESSION_DESKTOP \
+  XDG_SESSION_TYPE; do
+  if [[ -n "${!name-}" ]]; then
+    env_args+=(--env "$name=${!name}")
+  fi
+done
+
+command=(/usr/bin/fish)
+if [[ $# -gt 0 ]]; then
+  command+=("$@")
+fi
+
+exec podman exec \
+  --interactive \
+  --tty \
+  --user "$user" \
+  --workdir "$workdir" \
+  --env "PWD=$workdir" \
+  --env "CONTAINER_ID=$container" \
+  --env "DISTROBOX_ENTER_PATH=/usr/bin/distrobox-enter" \
+  "${env_args[@]}" \
+  "$container" \
+  "${command[@]}"


### PR DESCRIPTION
## Summary
- add a host-side Ptyxis wrapper that enters the running toolbox through direct podman exec
- document using the wrapper as the Ptyxis custom command for faster new tabs

## Validation
- bash -n host/fedora-toolbox-fast-shell
- shellcheck host/fedora-toolbox-fast-shell
- git diff --check
- local installed wrapper matches the repo helper